### PR TITLE
no spell overwrite on spell steal

### DIFF
--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -4280,9 +4280,13 @@ void Aura::HandlePeriodicTriggerSpell(bool apply, bool /*Real*/)
                     // Cast Wrath of the Plaguebringer if not dispelled
                     target->CastSpell(target, 29214, true, 0, this);
                 return;
-            case 42783:                                     //Wrath of the Astrom...
+            case 42783:                                     // Wrath of the Astrom...
                 if (m_removeMode == AURA_REMOVE_BY_EXPIRE && GetEffIndex() + 1 < MAX_EFFECT_INDEX)
                     target->CastSpell(target, GetSpellProto()->CalculateSimpleValue(SpellEffectIndex(GetEffIndex()+1)), true);
+                return;
+            case 43680:                                     // Idle
+                if (m_removeMode == AURA_REMOVE_BY_EXPIRE && target->GetTypeId() == TYPEID_PLAYER)
+                    ((Player*)target)->ToggleAFK();
                 return;
             default:
                 break;

--- a/src/game/SpellEffects.cpp
+++ b/src/game/SpellEffects.cpp
@@ -4936,6 +4936,24 @@ void Spell::EffectScriptEffect(SpellEffectIndex eff_idx)
                     unitTarget->CastSpell(unitTarget, 41131, true);
                     break;
                 }
+                case 44436:                                 // Item: Tricky Treats (Hallow's End)
+                {
+                    if (!m_caster->HasAura(42966))  // check for Upset Tummy
+                    {
+                        switch (urand(0,10))
+                        {
+                            case 0:
+                                m_caster->CastSpell(m_caster, 42966, true); // Upset Tummy
+                                break;
+                            default:
+                                m_caster->CastSpell(m_caster, 42919, true); // 30s Buff, +4% speed / buff
+                                m_caster->CastSpell(m_caster, 42965, true); // 5s Buff, +20% speed
+                        }
+                    }
+                    else
+                        m_caster->CastSpell(m_caster, 42966, true); // Upset Tummy
+                    break;
+                }
                 case 44876:                                 // Force Cast - Portal Effect: Sunwell Isle
                 {
                     if (!unitTarget)

--- a/src/game/SpellMgr.cpp
+++ b/src/game/SpellMgr.cpp
@@ -694,6 +694,7 @@ bool IsPositiveEffect(SpellEntry const *spellproto, SpellEffectIndex effIndex)
                         case 38637:                         // Nether Exhaustion (red)
                         case 38638:                         // Nether Exhaustion (green)
                         case 38639:                         // Nether Exhaustion (blue)
+                        case 42966:                         // Upset Tummy (Hallow's End)
                         case 44689:                         // Relay Race Accept Hidden Debuff - DND
                             return false;
                         // some spells have unclear target modes for selection, so just make effect positive

--- a/src/game/Unit.cpp
+++ b/src/game/Unit.cpp
@@ -4067,7 +4067,10 @@ void Unit::RemoveAurasDueToSpellBySteal(uint32 spellId, ObjectGuid casterGuid, U
     // strange but intended behaviour: Stolen single target auras won't be treated as single targeted
     new_holder->SetIsSingleTarget(false);
 
-    stealer->AddSpellAuraHolder(new_holder);
+    if (!stealer->HasAura(spellId) ||
+        (GetSpellAuraHolder(spellId, stealer->GetObjectGuid()) &&
+         GetSpellAuraHolder(spellId, stealer->GetObjectGuid())->GetAuraDuration() < new_max_dur))
+        stealer->AddSpellAuraHolder(new_holder);
 }
 
 void Unit::RemoveAurasDueToSpellByCancel(uint32 spellId)


### PR DESCRIPTION
spells stolen by spells like spell steal should not overwrite possible own aura with longer duration
